### PR TITLE
live method is deprecated

### DIFF
--- a/js/photoZoom.js
+++ b/js/photoZoom.js
@@ -52,7 +52,7 @@
                 var images = this.findImages();
                 if(images){
                     jQuery.each(images,function(i,imgObj){
-                        jQuery(imgObj).live({
+                        jQuery(imgObj).on({
                             mouseenter : function(){
                                 functions.whenHover(this);
                             },


### PR DESCRIPTION
The .live() method has been deprecated since jQuery 1.7 and has been removed in 1.9. I'm developing an 
app with the new source version (1.9) and this is the only thing that isn't work.
Just change the live method with .on() [in this case is the same] that and it will work
